### PR TITLE
Update the-heist.html and add buzzword.html

### DIFF
--- a/buzzword.html
+++ b/buzzword.html
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
-        <h1>The Heist</h1>
+        <h1>Buzzword</h1>
 
         <!-- Start Gamevy Embed code -->
         <div class="game-embed game-embed--the-heist"
@@ -15,7 +15,7 @@
              data-language="EN"
              data-environment="test"
              data-mode="fun"></div>
-        <script src="https://2d2bf377b3d36053cfbb-e13e7edd2ab3f770567ebd33c9402466.ssl.cf3.rackcdn.com/embed.js"></script>
+        <script src="https://cf6d228c202f3f5c8af6-a2b231d0e3707b80dec73d51497d6f4e.ssl.cf3.rackcdn.com/embed.js"></script>
         <!-- End Gamevy Embed code -->
 
       </div>

--- a/buzzword.html
+++ b/buzzword.html
@@ -18,6 +18,8 @@
         <script src="https://cf6d228c202f3f5c8af6-a2b231d0e3707b80dec73d51497d6f4e.ssl.cf3.rackcdn.com/embed.js"></script>
         <!-- End Gamevy Embed code -->
 
+        <a role="button" class="btn btn-primary pull-right" href="https://cf6d228c202f3f5c8af6-a2b231d0e3707b80dec73d51497d6f4e.ssl.cf3.rackcdn.com/index.html?env=test&amp;mode=fun">Play in full screen</a>
+
       </div>
     </div>
   </div>

--- a/the-heist.html
+++ b/the-heist.html
@@ -4,6 +4,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
+
         <h1>The Heist</h1>
 
         <!-- Start Gamevy Embed code -->
@@ -17,6 +18,8 @@
              data-mode="fun"></div>
         <script src="https://2d2bf377b3d36053cfbb-e13e7edd2ab3f770567ebd33c9402466.ssl.cf3.rackcdn.com/embed.js"></script>
         <!-- End Gamevy Embed code -->
+
+        <a role="button" class="btn btn-primary pull-right" href="https://2d2bf377b3d36053cfbb-e13e7edd2ab3f770567ebd33c9402466.ssl.cf3.rackcdn.com/index.html?env=test&amp;mode=fun">Play in full screen</a>
 
       </div>
     </div>


### PR DESCRIPTION
The url used on ```/the-heist``` was broken by the shipit cleaner and has been outdated anyway.

This also adds a "full screen" button, useful for mobile phones and playing the game without the gamevy stuff around it. 

Disclaimer: Buzzword's index.html doesn't work quite yet and the test.html is not linked. I guess it will be fixed soon.