### PR TITLE
Replace 'Play in full screen' with its German equivalent

### DIFF
--- a/buzzword-de.html
+++ b/buzzword-de.html
@@ -18,7 +18,7 @@
         <script src="https://38050b8429872a8d3654-52cd88461befb180e6ba6df9d51f2d49.ssl.cf3.rackcdn.com/embed.js"></script>
         <!-- End Gamevy Embed code -->
 
-        <a role="button" class="btn btn-primary pull-right" href="https://38050b8429872a8d3654-52cd88461befb180e6ba6df9d51f2d49.ssl.cf3.rackcdn.com/index.html?env=test&amp;mode=fun&amp;operator=gamevy&amp;lang=de-DE&amp;currency=EUR">Play in full screen</a>
+        <a role="button" class="btn btn-primary pull-right" href="https://38050b8429872a8d3654-52cd88461befb180e6ba6df9d51f2d49.ssl.cf3.rackcdn.com/index.html?env=test&amp;mode=fun&amp;operator=gamevy&amp;lang=de-DE&amp;currency=EUR">Spiele in Vollbild</a>
 
       </div>
     </div>

--- a/the-heist-de.html
+++ b/the-heist-de.html
@@ -19,7 +19,7 @@
         <script src="https://70234542b69db413cdd4-ec3382d217bd165415e45cc0dc163fa1.ssl.cf3.rackcdn.com/embed.js"></script>
         <!-- End Gamevy Embed code -->
 
-        <a role="button" class="btn btn-primary pull-right" href="https://70234542b69db413cdd4-ec3382d217bd165415e45cc0dc163fa1.ssl.cf3.rackcdn.com/index.html?env=test&amp;mode=fun&amp;operator=gamevy&amp;lang=de-DE&amp;currency=EUR">Play in full screen</a>
+        <a role="button" class="btn btn-primary pull-right" href="https://70234542b69db413cdd4-ec3382d217bd165415e45cc0dc163fa1.ssl.cf3.rackcdn.com/index.html?env=test&amp;mode=fun&amp;operator=gamevy&amp;lang=de-DE&amp;currency=EUR">Spiele in Vollbild</a>
 
       </div>
     </div>


### PR DESCRIPTION
I forgot to change the Play in full screen button on the German pages for The Heist and Buzzword. This makes good that mistake.